### PR TITLE
Add test to see if "spaced" version causes a warning

### DIFF
--- a/t/02-spaced_name.t
+++ b/t/02-spaced_name.t
@@ -1,0 +1,16 @@
+#!perl
+
+use 5.010;
+use strict;
+
+use Module::CoreList;
+use Module::CoreList::More;
+use Test::More 0.98;
+
+subtest spaced_version_no_warns => sub {
+  local $SIG{__WARN__} = sub { die $_[0] };
+  ok eval { Module::CoreList::More->is_core('CPAN::FirstTime',1) };
+};
+
+DONE_TESTING:
+done_testing;


### PR DESCRIPTION
Bug #124364 is about numeric warnings being emitted by Module::CoreList. This new test checks for that. (This is in reference to the NYC Hackathon challenge to review Module::CoreList::More for inclusion into the core Module::CoreList)
