### PR TITLE
Handle trailing spaces, letters (and other trailing junk) in versions

### DIFF
--- a/lib/Module/CoreList/More.pm
+++ b/lib/Module/CoreList/More.pm
@@ -10,7 +10,6 @@ use warnings;
 use Module::CoreList;
 
 sub is_core {
-    no warnings; # temporary, some version strings in %Module::CoreList::delta contain trailing space, e.g. "1.15 " which cause warning in version->parse()
 
     my $module = shift;
     $module = shift if eval { $module->isa(__PACKAGE__) } && @_ > 0 && defined($_[0]) && $_[0] =~ /^\w/;
@@ -33,8 +32,14 @@ sub is_core {
         } else {
             # we haven't found the first release where module is included
             if (exists $delta->{changed}{$module}) {
-                my $modver = $delta->{changed}{$module};
                 if (defined $module_version) {
+		    my $modver = $delta->{changed}{$module};
+		    if (defined $modver) {
+		      $modver =~ s/\s+$//; # Eliminate trailing space
+		      # for "alpha" version, turn trailing junk such as letters
+		      # to _ plus a number based on the first junk char
+		      $modver =~ s/([^.0-9_])[^.0-9_]*$/'_'.sprintf('%03d',ord $1)/e;
+		    };
                     if (version->parse($modver) >= version->parse($module_version)) {
                         $first_rel = $rel;
                     }
@@ -56,8 +61,6 @@ sub is_core {
 }
 
 sub is_still_core {
-    no warnings; # temporary, some version strings in %Module::CoreList::delta contain trailing space, e.g. "1.15 " which cause warning in version->parse()
-
     my $module = shift;
     $module = shift if eval { $module->isa(__PACKAGE__) } && @_ > 0 && defined($_[0]) && $_[0] =~ /^\w/;
     my ($module_version, $perl_version);
@@ -77,8 +80,14 @@ sub is_still_core {
         } else {
             # we haven't found the first release where module is included
             if (exists $delta->{changed}{$module}) {
-                my $modver = $delta->{changed}{$module};
                 if (defined $module_version) {
+		    my $modver = $delta->{changed}{$module};
+		    if (defined $modver) {
+		      $modver =~ s/\s+$//; # Eliminate trailing space
+		      # for "alpha" version, turn trailing junk such as letters
+		      # to _ plus a number based on the first junk char
+		      $modver =~ s/([^.0-9_])[^.0-9_]*$/'_'.sprintf('%03d',ord $1)/e;
+		    };
                     if (version->parse($modver) >= version->parse($module_version)) {
                         $first_rel = $rel;
                     }

--- a/t/02-spaced_name.t
+++ b/t/02-spaced_name.t
@@ -7,9 +7,41 @@ use Module::CoreList;
 use Module::CoreList::More;
 use Test::More 0.98;
 
-subtest spaced_version_no_warns => sub {
-  local $SIG{__WARN__} = sub { die $_[0] };
-  ok eval { Module::CoreList::More->is_core('CPAN::FirstTime',1) };
+# Make warnings a punishable offense
+local $SIG{__WARN__} = sub { die $_[0] };
+
+# A few modules to look at in detail
+my %mods_to_test =
+  (
+   'CPAN::FirstTime' => 'has a space at the end'
+   ,'CGI::Fast' => 'has a letter in "1.00a"'
+   ,'CPAN::Nox' => 'uses an underscore (like many other modules)'
+   ,'Unicode' => 'double-dotted version'
+  );
+
+
+sub check_mod_for_warning {
+  my ($mod,$why) = @_;
+  ok( eval {Module::CoreList::More->is_core($mod,0);1}, "is_core($mod) $why" );
+  diag "is_core($mod) warned: $@" if $@;
+
+  ok( eval {Module::CoreList::More->is_still_core($mod,0);1},
+      "is_still_core($mod) $why" );
+  diag "is_still_core($mod) warned: $@" if $@;
+}
+
+
+# run the specific tests in a random order
+while (my ($mod,$why) = each %mods_to_test) {
+  check_mod_for_warning($mod,$why);
+}
+
+subtest no_module_warns => sub {
+  my @mods = Module::CoreList::find_modules('.');
+  for my $mod (@mods) {
+    next if $mods_to_test{$mod};
+    check_mod_for_warning($mod,"vers");
+  }
 };
 
 DONE_TESTING:

--- a/t/02-spaced_name.t
+++ b/t/02-spaced_name.t
@@ -1,0 +1,16 @@
+#!perl
+
+use 5.010;
+use strict;
+
+use Module::CoreList;
+use Module::CoreList::More;
+use Test::More 0.98;
+
+subtest spaced_version_no_warns => sub {
+  local $SIG{__WARN__} = sub { die $_[0] };
+  ok eval { Module::CoreList::More->is_core('CPAN::FirstTime',1) };
+};
+
+DONE_TESTING:
+done_testing;


### PR DESCRIPTION
There are a few "bad" version numbers in Module::CoreList. Trailing spaces emit warnings- but at the moment those trailing spaces should be left in, as they indicate a likely CVS source, which a future hacker might want to convert into "v"-strings. This patch handles trailing spaces by stripping them before handing it to version->parse. This is more precise than using "no warnings", which I've now removed.

There is also one module that was released with a trailing letter "a", and version.pm only wants digits, "." and ".", so this patch converts a trailing letter to underscore plus its ASCII code. This matches the likely intent of calling it an alpha release, and will compare "a" as less than "b".

(this includes and supersedes my earlier pull request)
