### PR TITLE
More wantarray test cases for first_release

### DIFF
--- a/lib/Module/CoreList/More.pm
+++ b/lib/Module/CoreList/More.pm
@@ -7,7 +7,7 @@ use 5.010001;
 use strict;
 use warnings;
 
-use Module::CoreList;
+use Module::CoreList ();
 
 sub _firstidx {
     my ($item, $ary) = @_;

--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -4,7 +4,6 @@ use 5.010;
 use strict;
 use warnings;
 
-use Module::CoreList;
 use Module::CoreList::More;
 use Test::More 0.98;
 
@@ -18,8 +17,11 @@ subtest first_release => sub {
     my $i = -1;
     for my $test (@tests) {
         $i++;
+        # Try as both function and method
         is_deeply(scalar(Module::CoreList::More->first_release(@{$test->{args}})),
-                  $test->{answer}, "$i ($test->{args}[0])");
+		  $test->{answer}, "$i ($test->{args}[0])");
+        is_deeply(scalar(Module::CoreList::More::first_release(@{$test->{args}})),
+		  $test->{answer}, "$i ($test->{args}[0])");
     }
 };
 
@@ -33,16 +35,28 @@ subtest first_release_by_date => sub {
     my $i = -1;
     for my $test (@tests) {
         $i++;
+        # Try as both function and method
         is_deeply(scalar(Module::CoreList::More->first_release_by_date(@{$test->{args}})),
+                  $test->{answer}, "$i ($test->{args}[0])");
+        is_deeply(scalar(Module::CoreList::More::first_release_by_date(@{$test->{args}})),
                   $test->{answer}, "$i ($test->{args}[0])");
     }
 };
 
-subtest first_release_list_context => sub {
-  ok(@{[Module::CoreList::More->first_release('Foo')]} == 0,
-     'first_release returns empty list');
-  ok(@{[Module::CoreList::More->first_release_by_date('Foo')]} == 0,
-     'first_release_by_date returns empty list');
+subtest list_context_first_release => sub {
+  my @tests = (
+        {args=>['Foo'], answer=>[]},
+        {args=>['Carp'], answer=>['5']},
+        {args=>['CGI'], answer=>['5.004']},
+	      );
+
+  for my $test (@tests) {
+    my @args = @{$test->{args}};
+    is_deeply([Module::CoreList::More->first_release(@args)],
+      $test->{answer}, "first_release @args");
+    is_deeply([Module::CoreList::More->first_release_by_date(@args)],
+      $test->{answer}, "first_release_by_date @args");
+  }
 };
 
 subtest is_core => sub {


### PR DESCRIPTION
Added cases where the array-context first_release succeeds, in addition
to existing not-found case.

Added funtion-call first_release tests, in addition to method call
case... Dear reader, you may wish to also add sub call tests for the
other routines in this module.

Removed "use Module::CoreList" from the test, and is now explicit about
not importing anything in the module, it isn't needed and might be
confusing.
